### PR TITLE
Add research and write modes

### DIFF
--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -13,7 +13,10 @@ export const formatResponse = {
 	condense: () =>
 		`The user has accepted the condensed conversation summary you generated. This summary covers important details of the historical conversation with the user which has been truncated.\n<explicit_instructions type="condense_response">It's crucial that you respond by ONLY asking the user what you should work on next. You should NOT take any initiative or make any assumptions about continuing with work. For example you should NOT suggest file changes or attempt to read any files.\nWhen asking the user what you should work on next, you can reference information in the summary which was just generated. However, you should NOT reference information outside of what's contained in the summary for this response. Keep this response CONCISE.</explicit_instructions>`,
 
-	toolDenied: () => `The user denied this operation.`,
+        toolDenied: () => `The user denied this operation.`,
+
+        toolNotAllowedInMode: (mode: string) =>
+                `This tool is not available while in ${mode.toUpperCase()} mode.`,
 
 	toolError: (error?: string) => `The tool execution failed with the following error:\n<error>\n${error}\n</error>`,
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1618,8 +1618,8 @@ export class Task {
 
 	// Check if the tool should be auto-approved based on the settings
 	// Returns bool for most tools, and tuple for tools with nested settings
-	shouldAutoApproveTool(toolName: ToolUseName): boolean | [boolean, boolean] {
-		if (this.autoApprovalSettings.enabled) {
+        shouldAutoApproveTool(toolName: ToolUseName): boolean | [boolean, boolean] {
+                if (this.autoApprovalSettings.enabled) {
 			switch (toolName) {
 				case "read_file":
 				case "list_files":
@@ -1656,15 +1656,15 @@ export class Task {
 	// Check if the tool should be auto-approved based on the settings
 	// and the path of the action. Returns true if the tool should be auto-approved
 	// based on the user's settings and the path of the action.
-	shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): boolean {
-		let isLocalRead: boolean = false
-		if (autoApproveActionpath) {
-			const absolutePath = path.resolve(cwd, autoApproveActionpath)
-			isLocalRead = absolutePath.startsWith(cwd)
-		} else {
-			// If we do not get a path for some reason, default to a (safer) false return
-			isLocalRead = false
-		}
+        shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): boolean {
+                let isLocalRead: boolean = false
+                if (autoApproveActionpath) {
+                        const absolutePath = path.resolve(cwd, autoApproveActionpath)
+                        isLocalRead = absolutePath.startsWith(cwd)
+                } else {
+                        // If we do not get a path for some reason, default to a (safer) false return
+                        isLocalRead = false
+                }
 
 		// Get auto-approve settings for local and external edits
 		const autoApproveResult = this.shouldAutoApproveTool(blockname)
@@ -1672,12 +1672,22 @@ export class Task {
 			? autoApproveResult
 			: [autoApproveResult, false]
 
-		if ((isLocalRead && autoApproveLocal) || (!isLocalRead && autoApproveLocal && autoApproveExternal)) {
-			return true
-		} else {
-			return false
-		}
-	}
+                if ((isLocalRead && autoApproveLocal) || (!isLocalRead && autoApproveLocal && autoApproveExternal)) {
+                        return true
+                } else {
+                        return false
+                }
+        }
+
+        // Determines whether a tool is allowed based on the current mode
+        private isToolPermitted(toolName: ToolUseName): boolean {
+                const editingTools = ["write_to_file", "replace_in_file", "new_rule", "execute_command"]
+                if (this.chatSettings.mode === "research" || this.chatSettings.mode === "plan") {
+                        return !editingTools.includes(toolName)
+                }
+                // "write" or "act" modes allow all tools
+                return true
+        }
 
 	private formatErrorWithStatusCode(error: any): string {
 		const statusCode = error.status || error.statusCode || (error.response && error.response.status)
@@ -2320,11 +2330,16 @@ export class Task {
 					await this.browserSession.closeBrowser()
 				}
 
-				switch (block.name) {
-					case "new_rule":
-					case "write_to_file":
-					case "replace_in_file": {
-						const relPath: string | undefined = block.params.path
+                                switch (block.name) {
+                                        case "new_rule":
+                                        case "write_to_file":
+                                        case "replace_in_file": {
+                                                if (!this.isToolPermitted(block.name)) {
+                                                        pushToolResult(formatResponse.toolNotAllowedInMode(this.chatSettings.mode))
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                }
+                                                const relPath: string | undefined = block.params.path
 						let content: string | undefined = block.params.content // for write_to_file
 						let diff: string | undefined = block.params.diff // for replace_in_file
 						if (!relPath || (!content && !diff)) {
@@ -3214,8 +3229,13 @@ export class Task {
 							break
 						}
 					}
-					case "execute_command": {
-						let command: string | undefined = block.params.command
+                                        case "execute_command": {
+                                                if (!this.isToolPermitted(block.name)) {
+                                                        pushToolResult(formatResponse.toolNotAllowedInMode(this.chatSettings.mode))
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                }
+                                                let command: string | undefined = block.params.command
 						const requiresApprovalRaw: string | undefined = block.params.requires_approval
 						const requiresApprovalPerLLM = requiresApprovalRaw?.toLowerCase() === "true"
 
@@ -5095,12 +5115,16 @@ export class Task {
 		details += "\n\n# Context Window Usage"
 		details += `\n${lastApiReqTotalTokens.toLocaleString()} / ${(contextWindow / 1000).toLocaleString()}K tokens used (${usagePercentage}%)`
 
-		details += "\n\n# Current Mode"
-		if (this.chatSettings.mode === "plan") {
-			details += "\nPLAN MODE\n" + formatResponse.planModeInstructions()
-		} else {
-			details += "\nACT MODE"
-		}
+                details += "\n\n# Current Mode"
+                if (this.chatSettings.mode === "plan") {
+                        details += "\nPLAN MODE\n" + formatResponse.planModeInstructions()
+                } else if (this.chatSettings.mode === "research") {
+                        details += "\nRESEARCH MODE"
+                } else if (this.chatSettings.mode === "write") {
+                        details += "\nWRITE MODE"
+                } else {
+                        details += "\nACT MODE"
+                }
 
 		return `<environment_details>\n${details.trim()}\n</environment_details>`
 	}

--- a/src/shared/ChatSettings.ts
+++ b/src/shared/ChatSettings.ts
@@ -1,9 +1,9 @@
 export type OpenAIReasoningEffort = "low" | "medium" | "high"
 
 export interface ChatSettings {
-	mode: "plan" | "act"
-	preferredLanguage?: string
-	openAIReasoningEffort?: OpenAIReasoningEffort
+        mode: "plan" | "act" | "research" | "write"
+        preferredLanguage?: string
+        openAIReasoningEffort?: OpenAIReasoningEffort
 }
 
 export type PartialChatSettings = Partial<ChatSettings>


### PR DESCRIPTION
## Summary
- allow ChatSettings to specify research or write modes
- warn when a disallowed tool is used in restricted modes
- show current mode in environment details

## Testing
- `npm run check-types` *(fails: Cannot find package 'globby')*
- `npm test` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6865837e767c832a8d886811f691a3f6