### PR TITLE
Revise docs for writing scenarios

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,7 +2,7 @@
 	"$schema": "https://mintlify.com/docs.json",
 	"theme": "linden",
 	"name": "Cline",
-	"description": "AI-powered coding assistant for VSCode",
+        "description": "AI-powered writing assistant for VSCode",
 	"colors": {
 		"primary": "#9D4EDD",
 		"light": "#F0E6FF",
@@ -78,7 +78,8 @@
 					"features/checkpoints",
 					"features/cline-rules",
 					"features/drag-and-drop",
-					"features/plan-and-act",
+                                        "features/plan-and-act",
+                                        "features/writing-tools",
 					"features/slash-commands/workflows",
 					"features/editing-messages",
 					{

--- a/docs/features/at-mentions/overview.mdx
+++ b/docs/features/at-mentions/overview.mdx
@@ -3,13 +3,13 @@ title: "@ Mentions Overview"
 sidebarTitle: "Overview"
 ---
 
-@ mentions are one of Cline's most powerful features, letting you seamlessly bring external context into your conversations. Instead of copying and pasting code, error messages, or documentation, you can simply reference them with an @ symbol.
+@ mentions are one of Cline's most powerful features, letting you seamlessly bring external context into your conversations. Instead of copying and pasting chapters, research notes, or links, you can simply reference them with an @ symbol.
 
 <Frame>
 	<img src="https://storage.googleapis.com/cline_public_images/docs/assets/at-mentions.png" alt="@ Mentions Overview" />
 </Frame>
 
-When you type `@` in the chat input, Cline shows a menu of available mention types. These mentions let you reference files, folders, problems, terminal output, git changes, and even web content directly in your conversations.
+When you type `@` in the chat input, Cline shows a menu of available mention types. These mentions let you reference files, folders, research notes, and web content directly in your conversations.
 
 ## Available @ Mentions
 
@@ -17,65 +17,46 @@ Cline supports several types of @ mentions, each designed to bring different kin
 
 <Columns cols={2}>
   <Card title="File Mentions" icon="file" href="/features/at-mentions/file-mentions">
-    Reference any file in your workspace with `@/path/to/file`. Cline sees the complete file content, including imports, related
-    functions, and surrounding context.
+    Reference any file in your workspace with `@/path/to/file`. Cline sees the complete text, making it easy to discuss chapters or notes.
   </Card>
 
 {" "}
 
 <Card title="Folder Mentions" icon="folder" href="/features/at-mentions/folder-mentions">
-	Reference entire directories with `@/path/to/folder/`. Cline sees the folder structure and all file contents, perfect for
-	understanding complex interactions between multiple files.
+        Reference entire directories with `@/path/to/folder/`. Cline sees the folder structure and all files, perfect for managing large manuscripts.
 </Card>
 
 {" "}
 
-<Card title="Problem Mentions" icon="triangle-exclamation" href="/features/at-mentions/problem-mentions">
-	Use `@problems` to show Cline all the errors and warnings in your workspace. Cline sees the complete list with file locations
-	and error messages.
+<Card title="Note Mentions" icon="sticky-note" href="/features/at-mentions/problem-mentions">
+        Use `@notes` to pull in your research or brainstorming notes so Cline can reference them while drafting.
 </Card>
 
 {" "}
 
-<Card title="Terminal Mentions" icon="terminal" href="/features/at-mentions/terminal-mentions">
-	Use `@terminal` to share your recent terminal output. Cline sees the complete output with formatting preserved, perfect for
-	debugging build errors or test failures.
+<Card title="URL Mentions" icon="globe" href="/features/at-mentions/url-mentions">
+    Reference web content with `@https://example.com`. Cline fetches the complete webpage text—great for citing articles or scripts online.
 </Card>
-
-{" "}
-
-<Card title="Git Mentions" icon="code-branch" href="/features/at-mentions/git-mentions">
-	Reference uncommitted changes with `@git-changes` or specific commits with `@[commit-hash]`. Cline sees the complete diff,
-	commit message, and other relevant information.
-</Card>
-
-  <Card title="URL Mentions" icon="globe" href="/features/at-mentions/url-mentions">
-    Reference web content with `@https://example.com`. Cline fetches and sees the complete webpage content, perfect for
-    referencing documentation or GitHub issues.
-  </Card>
 </Columns>
 
 ## Why @ Mentions Matter
 
 @ mentions transform how you interact with Cline by:
 
-1. **Eliminating copy-paste**: No more copying and pasting code, error messages, or terminal output. Just reference them directly.
+1. **Eliminating copy-paste**: No more copying chapters or research links by hand. Just reference them directly.
 
-2. **Preserving context**: Cline sees the complete context, including imports, related functions, and surrounding code that might be relevant.
+2. **Preserving context**: Cline sees the full text around your reference, ensuring edits stay consistent.
 
-3. **Maintaining formatting**: Terminal output, error messages, and web content keep their formatting, making them easier to understand.
+3. **Maintaining formatting**: Web pages and notes keep their formatting, making citations easier.
 
-4. **Enabling complex workflows**: Combine multiple @ mentions to give Cline a complete picture of your problem:
+4. **Enabling complex workflows**: Combine multiple @ mentions to give Cline a complete picture of your work:
 
     ```
-    I'm getting these errors: @problems
+    Here's my outline: @/outline.md
 
-    Here's my component: @/src/components/Form.jsx
-    And the API endpoint: @/src/api/users.js
+    Include this reference: @https://example.com/article
 
-    The error happens when I submit: @terminal
-
-    I think this commit might have caused it: @a1b2c3d
+    Don't forget my notes: @notes
     ```
 
 ## Getting Started

--- a/docs/features/commands-and-shortcuts/overview.mdx
+++ b/docs/features/commands-and-shortcuts/overview.mdx
@@ -3,7 +3,7 @@ title: "Commands & Shortcuts Overview"
 sidebarTitle: "Overview"
 ---
 
-Cline integrates directly into VSCode's interface, letting you access AI assistance without disrupting your workflow. These integrations appear as commands in context menus, keyboard shortcuts, and quick fixes throughout the editor.
+Cline integrates directly into VSCode's interface, letting you access AI writing assistance without leaving your document. These integrations appear as commands in context menus, keyboard shortcuts, and quick fixes throughout the editor.
 
 <Frame>
 	<img
@@ -14,42 +14,38 @@ Cline integrates directly into VSCode's interface, letting you access AI assista
 
 ### What are Editor Integrations?
 
-Editor integrations are commands and shortcuts that let you use Cline right where you're working. Instead of switching to the Cline panel first, you can select code, right-click, and immediately send it to Cline for help.
+Editor integrations let you use Cline right where you're writing. Instead of copying and pasting passages into chat, you can highlight text, right-click, and ask Cline to outline, edit, or summarize.
 These integrations appear in different places throughout VSCode:
 
--   In the editor context menu (right-click menu) - "Add to Cline"
--   In the terminal context menu - "Add to Cline"
--   In the Source Control view - "Generate Commit Message"
+-   In the editor context menu (right-click menu) - "Send to Cline"
 -   As keyboard shortcuts - Various Cline commands
--   As Quick Fix options (lightbulb menu) - "Fix with Cline", "Explain with Cline", "Improve with Cline"
+-   As Quick Fix options (lightbulb menu) - "Rewrite with Cline", "Summarize with Cline"
 
 ### Available Editor Integrations
 
 Cline offers several editor integrations, each designed to enhance different aspects of your development workflow:
 
 <Columns cols={2}>
-  <Card title="Code Commands" icon="code" href="/features/commands-and-shortcuts/code-commands">
-    Right-click on code to add it to Cline, or use the lightbulb menu to fix errors, explain code, or improve it. Cline sees the complete code context, including imports and surrounding functions.
+  <Card title="Text Commands" icon="file-lines" href="/features/commands-and-shortcuts/code-commands">
+    Highlight a paragraph and ask Cline to rewrite, summarize, or expand it. Cline keeps the surrounding context so edits fit naturally.
   </Card>
 
 {" "}
 
-<Card title="Terminal Integration" icon="terminal" href="/features/commands-and-shortcuts/terminal-integration">
-	Add terminal output to Cline with a right-click or use `@terminal` mentions. Perfect for debugging build errors, test
-	failures, or runtime issues.
+<Card title="Research Links" icon="book" href="/features/commands-and-shortcuts/terminal-integration">
+        Right-click a citation or URL to fetch references for you. Great for academic writing or gathering background material.
 </Card>
 
 {" "}
 
-<Card title="Git Integration" icon="code-branch" href="/features/commands-and-shortcuts/git-integration">
-	Generate commit messages, explain diffs, or analyze changes with Cline's Git integration. Cline understands your version
-	control context.
+<Card title="Version History" icon="clock" href="/features/commands-and-shortcuts/git-integration">
+        Track revisions of your manuscript and ask Cline to summarize changes between drafts.
 </Card>
 
 {" "}
 
 <Card title="Keyboard Shortcuts" icon="keyboard" href="/features/commands-and-shortcuts/keyboard-shortcuts">
-	Speed up your workflow with keyboard shortcuts for common Cline actions. Quickly add code to chat, fix errors, or improve your code.
+        Speed up your workflow with shortcuts for outlining, drafting, and revising text.
 </Card>
 </Columns>
 
@@ -57,7 +53,7 @@ Cline offers several editor integrations, each designed to enhance different asp
 
 When you use these commands, Cline:
 
--   Captures the relevant context (selected code, file path, terminal output, etc.)
+-   Captures the relevant context (selected text, file path, or reference)
 -   Focuses the Cline interface
 -   Creates a conversation with the captured context
 -   In some cases, automatically generates a suggested prompt

--- a/docs/features/plan-and-act.mdx
+++ b/docs/features/plan-and-act.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Plan & Act"
-sidebarTitle: "Plan & Act"
+title: "Plan & Draft"
+sidebarTitle: "Plan & Draft"
 ---
 
-Plan & Act modes represent Cline's approach to structured AI development, emphasizing thoughtful planning before implementation. This dual-mode system helps developers create more maintainable, accurate code while reducing iteration time.
+Plan & Draft modes help writers move from brainstorming to polished prose. Planning keeps ideas organized, while Draft mode turns those plans into chapters, papers, or scenes.
 
 <Frame>
 	<iframe
@@ -17,44 +17,44 @@ Plan & Act modes represent Cline's approach to structured AI development, emphas
 
 #### Plan Mode: Think First
 
-Plan mode is where you and Cline figure out what you're trying to build and how you'll build it. In this mode, Cline:
+Plan mode is where you and Cline shape the outline of your work. In this mode, Cline:
 
--   Can read your entire codebase to understand the context
--   Won't make any changes to your files
--   Focuses on understanding requirements and creating a strategy
--   Helps identify potential issues before you write a single line of code
+-   Can read your existing drafts or research notes to understand the context
+-   Won't alter your files yet
+-   Focuses on organizing ideas and creating a structure
+-   Helps identify gaps before you draft a single paragraph
 
-#### Act Mode: Build It
+#### Draft Mode: Write It
 
-Once you've got a plan, you switch to Act mode. Now Cline:
+Once the outline is ready, switch to Draft mode. Now Cline:
 
--   Has all the building capabilities at its disposal
--   Can make changes to your codebase
--   Still remembers everything from your planning session
--   Executes the strategy you worked out together
+-   Expands sections using the agreed plan
+-   Can modify your manuscript or script files
+-   Keeps everything from the planning session in context
+-   Executes the structure you created together
 
 <Frame>
-	<img src="https://storage.googleapis.com/cline_public_images/docs/assets/image%20(5).png" alt="Act mode capabilities" />
+        <img src="https://storage.googleapis.com/cline_public_images/docs/assets/image%20(5).png" alt="Draft mode capabilities" />
 </Frame>
 
 ### Workflow Guide
 
-When I'm working on a new feature or fixing a complex bug, here's what works for me:
+When outlining a novel or organizing a research paper, here's what works for me:
 
-1. I start in Plan mode and tell Cline what I want to build
-2. Cline helps me explore the codebase, looking at relevant files
-3. Together we figure out the best approach, considering edge cases and potential issues
-4. When I'm confident in our plan, I switch to Act mode
-5. Cline implements the solution based on our planning
+1. I start in Plan mode and explain the concept or thesis
+2. Cline helps me review existing notes and sources
+3. Together we craft a chapter or section outline
+4. When I'm confident in the outline, I switch to Draft mode
+5. Cline expands each section according to the plan
 
 #### 1. Start with Plan Mode
 
-Begin every significant development task in Plan mode:
+Begin every significant writing project in Plan mode:
 
 In this mode:
 
 <Frame>
-	<img src="https://storage.googleapis.com/cline_public_images/docs/assets/image%20(5)%20(1).png" alt="Plan mode workflow" />
+        <img src="https://storage.googleapis.com/cline_public_images/docs/assets/image%20(5)%20(1).png" alt="Plan mode workflow" />
 </Frame>
 
 -   Share your requirements
@@ -69,27 +69,27 @@ In this mode:
 	/>
 </Frame>
 
-#### 2. Switch to Act Mode
+#### 2. Switch to Draft Mode
 
-Once you have a clear plan, switch to Act mode:
+Once you have a clear outline, switch to Draft mode:
 
 <Frame>
-	<img src="https://storage.googleapis.com/cline_public_images/docs/assets/switching-to-act.gif" alt="Switching to Act mode" />
+        <img src="https://storage.googleapis.com/cline_public_images/docs/assets/switching-to-act.gif" alt="Switching to Draft mode" />
 </Frame>
 
-Act mode allows Cline to:
+Draft mode allows Cline to:
 
--   Execute against the agreed plan
--   Make changes to your codebase
+-   Execute against the agreed outline
+-   Edit your manuscript files
 -   Maintain context from planning phase
 
 #### 3. Iterate as Needed
 
-Complex projects often require multiple plan-act cycles:
+Long projects often require multiple plan-draft cycles:
 
--   Return to Plan mode when encountering unexpected complexity
--   Use Act mode for implementing solutions
--   Maintain development momentum while ensuring quality
+-   Return to Plan mode when adding new ideas or research
+-   Use Draft mode for writing passages
+-   Maintain momentum while keeping structure intact
 
 ### Best Practices
 
@@ -129,17 +129,17 @@ Complex projects often require multiple plan-act cycles:
 
 I've found Plan mode works best when:
 
--   Starting something new where the approach isn't obvious
--   Debugging a tricky issue where I'm not sure what's wrong
--   Making architectural decisions that will affect multiple parts of the codebase
--   Trying to understand a complex workflow or feature
+-   Starting a new story or article and the structure isn't clear
+-   Researching sources and deciding how to cite them
+-   Mapping character arcs or key arguments
+-   Evaluating feedback before large revisions
 
-And Act mode is perfect for:
+And Draft mode is perfect for:
 
--   Implementing a solution we've already planned out
--   Making routine changes where the approach is clear
--   Following established patterns in the codebase
--   Running tests and making minor adjustments
+-   Expanding an outline we've already agreed on
+-   Polishing dialogue or paragraphs
+-   Incorporating citations or scene directions
+-   Making incremental improvements
 
 <Frame>
 	<img src="https://storage.googleapis.com/cline_public_images/docs/assets/image%20(6).png" alt="Mode usage patterns" />

--- a/docs/features/writing-tools.mdx
+++ b/docs/features/writing-tools.mdx
@@ -1,0 +1,49 @@
+---
+title: "Writing Tools"
+description: "Overview of the special tools and modes available for writers."
+---
+
+Cline includes several tools designed specifically for long-form writing projects. Below are the most common ones and examples of how to use them.
+
+## Outline Mode
+
+Use Outline mode to plan the structure of a novel, paper, or script before drafting.
+
+```text
+/newtask mode:outline
+```
+
+Cline will prompt you for a high-level summary and then generate a chapter or scene breakdown.
+
+## Draft Mode
+
+Draft mode lets Cline expand sections of your outline into full prose. Provide the outline file or paragraph you want to develop and Cline will keep the structure intact.
+
+```text
+/draft @/outline.md section:2
+```
+
+This command asks Cline to focus on the second section of your outline.
+
+## Reference Manager
+
+The `reference_lookup` tool fetches citations for academic writing. Provide a DOI or URL and Cline will insert a formatted reference.
+
+```xml
+<reference_lookup>
+<url>https://doi.org/10.1000/example</url>
+<style>APA</style>
+</reference_lookup>
+```
+
+## Screenplay Formatter
+
+When working on a script, use the `format_screenplay` tool to ensure that scenes follow standard screenplay conventions.
+
+```xml
+<format_screenplay>
+<path>scenes/scene1.md</path>
+</format_screenplay>
+```
+
+These tools combined with Plan and Draft modes help you manage large writing projects from outline to finished manuscript.

--- a/docs/getting-started/for-new-coders.mdx
+++ b/docs/getting-started/for-new-coders.mdx
@@ -1,68 +1,50 @@
 ---
-title: "For New Coders"
-description: "Welcome to Cline, your AI-powered coding companion! This guide will help you quickly set up your development environment and begin your coding journey with ease."
+title: "For New Writers"
+description: "Welcome to Cline, your AI-powered writing companion! This guide helps you set up your environment and start outlining your next story."
 ---
 
-> 💡 **Tip:** If you're completely new to coding, take your time with each step. There's no rush — Cline is here to guide you!
+> 💡 **Tip:** If you're completely new to creative writing, take your time with each step. There's no rush — Cline is here to help shape your ideas!
 
 ### 🚀 Getting Started
 
-Before you jump into coding, make sure you have these essentials ready:
+Before you dive into a novel, screenplay, or research paper, make sure you have these essentials ready:
 
 #### 1. **VS Code**
 
-A popular, free, and powerful code editor.
+A flexible editor that's perfect for drafting text.
 
 -   [<u>Download VS Code</u>](https://code.visualstudio.com/)
+-   Install the **Cline** extension from the Marketplace.
 
-📺 **Recommended YouTube Tutorial:** [<u>How to Install VS Code</u>](https://www.youtube.com/watch?v=MlIzFUI1QGA)
-
-> ✅ **Pro Tip:** Install VS Code in your Applications folder (macOS) or Program Files (Windows) for easy access from your dock or start menu.
+> ✅ **Pro Tip:** Place VS Code in your Applications folder (macOS) or Program Files (Windows) for quick access.
 
 #### 2. **Organize Your Projects**
 
-Create a dedicated folder named `Cline` in your Documents folder for all your coding projects:
+Create a folder named `ClineWriting` in your Documents folder for all your drafts:
 
--   **macOS:** `/Users/[your-username]/Documents/Cline`
--   **Windows:** `C:\Users\[your-username]\Documents\Cline`
+-   **macOS:** `/Users/[your-username]/Documents/ClineWriting`
+-   **Windows:** `C:\Users\[your-username]\Documents\ClineWriting`
 
-Inside your `Cline` folder, structure projects clearly:
+Inside, organize by project:
 
--   `Documents/Cline/workout-app` _(e.g., for a fitness tracking app)_
--   `Documents/Cline/portfolio-website` _(e.g., to showcase your work)_
+-   `ClineWriting/my-novel`
+-   `ClineWriting/my-screenplay`
+-   `ClineWriting/my-thesis`
 
-> 💡 **Tip:** Keeping your projects organized from the start will save you time and confusion later!
+> 💡 **Tip:** A clear structure helps Cline track your outlines, drafts, and research notes.
 
-#### 3. **Install the Cline VS Code Extension**
+#### 3. **Outline Mode**
 
-Enhance your coding workflow by installing the Cline extension directly within VS Code:
+Use **Outline Mode** to brainstorm scenes or sections before writing:
 
--   Get Started with Cline Extension Tutorial
+1. Open a new task and choose **Outline Mode**.
+2. Describe the premise of your story, paper, or script.
+3. Let Cline suggest chapter breakdowns, research sections, or scene lists.
 
-📺 **Recommended YouTube Tutorial:** [<u>How To Install Extensions in VS Code</u>](https://www.youtube.com/watch?v=E7trgwZa-mk)
+> ✅ **Pro Tip:** Save the outline in your project folder so you can refine it later.
 
-> ✅ **Pro Tip:** After installing, reload VS Code to ensure the extension is activated properly.
+#### 4. **Draft Mode**
 
-#### 4. **Essential Development Tools**
+Switch to **Draft Mode** when you're ready to expand the outline into full text. Cline will keep the structure intact while helping you write scenes or sections.
 
-Basic software required for coding efficiently:
-
--   Homebrew (macOS)
--   Node.js
--   Git
-
-👉 [<u>Follow our detailed guide on Installing Essential Development Tools with step-by-step help from Cline.</u>](https://docs.cline.bot/getting-started/installing-dev-essentials#installing-dev-essentials)
-
-📺 **Recommended YouTube Tutorials for Manual Installation:**
-
--   **For macOS:**
-    -   [<u>Install Homebrew on Mac</u>](https://www.youtube.com/watch?v=hwGNgVbqasc)
-    -   [<u>Install Git on macOS 2024</u>](https://www.youtube.com/watch?v=B4qsvQ5IqWk)
-    -   [<u>Install Node.js on Mac (M1 | M2 | M3)</u>](https://www.youtube.com/watch?v=I8H4wolRFBk)
--   **For Windows:**
-    -   [<u>Install Git on Windows 10/11 (2024)</u>](https://www.youtube.com/watch?v=yjxv1HuRQy0)
-    -   [<u>Install Node.js in Windows 10/11</u>](https://www.youtube.com/watch?v=uCgAuOYpJd0)
-
-> ⚠️ **Note:** If you run into permission issues during installation, try running your terminal or command prompt as an administrator.
-
-🎉 You're all set! Dive in and start coding smarter and faster with **Cline**.
+🎉 You're all set! Start exploring your ideas with **Cline** and build your first draft.

--- a/docs/getting-started/our-favorite-tech-stack.mdx
+++ b/docs/getting-started/our-favorite-tech-stack.mdx
@@ -1,238 +1,33 @@
 ---
-title: "Our Favorite Tech Stack"
-description: "A curated list of our recommended technologies and tools for building modern web applications with Cline."
+title: "Our Favorite Writing Stack"
+description: "Recommended tools and workflows for outlining and drafting with Cline."
 ---
 
-## Recommended Stack for New Cline Users (2025)
+## Recommended Setup for New Writers
 
-### Your Complete Development Environment
+### Core Tools
 
-#### Development Tools
+- **VS Code** with the Cline extension installed
+- **Markdown** for easy version control of outlines and drafts
+- **Zotero** or your favorite reference manager for research-heavy projects
 
--   **VS Code** - Your code editor, [download here](https://code.visualstudio.com/)
--   **GitHub** - Where your code lives, [sign up here](https://github.com)
+### Example Workflow
 
-#### Frontend
+1. Start a project folder and create an `outline.md` file.
+2. Use **Outline Mode** to sketch chapters, sections, or scenes.
+3. Switch to **Draft Mode** to expand each item in your outline.
+4. Keep notes and references in a `references/` folder so Cline can cite them when drafting.
 
--   **Next.js 14+** - React framework with App Router
--   **Tailwind CSS** - Beautiful styling without writing CSS
--   **TypeScript** - JavaScript, but safer and smarter
+### Sample Project Structure
 
-#### Backend
-
--   **Supabase** - Your complete backend solution, [sign up with GitHub](https://supabase.com)
-    -   PostgreSQL database
-    -   Authentication
-    -   File storage
-    -   Real-time updates
-
-#### Deployment
-
--   **Vercel** - Where your app runs, [sign up with GitHub](https://vercel.com)
-    -   Automatic deployments from GitHub
-    -   Preview deployments for testing
-    -   Production-ready CDN
-
-#### AI Development
-
-Choose your AI assistant based on your needs:
-
-| Model             | Input Cost (per 1M tokens) | Output Cost (per 1M tokens) | Best For                       |
-| ----------------- | -------------------------- | --------------------------- | ------------------------------ |
-| Claude 3.5 Sonnet | $3.00                      | $15.00                      | Production apps, complex tasks |
-| DeepSeek R1       | $1.00                      | $3.00                       | Budget-conscious production    |
-| DeepSeek V3       | $0.14                      | $2.20                       | Budget-conscious development   |
-
-#### Free Tier Benefits
-
-**Vercel (Hobby)**
-
--   100 GB data transfer/month
--   100k serverless function invocations
--   100 MB deployment size
--   Automatic HTTPS & CI/CD
-
-**Supabase (Free)**
-
--   500 MB database storage
--   1 GB file storage
--   50k monthly active users
--   2M real-time messages/month
-
-**GitHub (Free)**
-
--   Unlimited public repositories
--   GitHub Actions CI/CD
--   Project management tools
--   Collaboration features
-
-### Getting Started
-
-1. Install the development essentials:
-    - Follow our [Development Essentials Installation Guide](https://docs.cline.bot/getting-started/installing-dev-essentials)
-2. Set up Cline's Memory Bank:
-    - Follow the [Memory Bank setup instructions](https://docs.cline.bot/prompting/cline-memory-bank)
-    - Create an empty `cline_docs` folder in your project root
-    - Create `projectBrief.md` in the `cline_docs` folder (see example below)
-    - Tell Cline to "initialize memory bank"
-3. Add our recommended stack configuration:
-    - Create `.clinerules` file (see template below)
-    - Let Cline handle the rest!
-
-#### Example Project Brief
-
-```markdown
-# Project Brief
-
-## Overview
-
-Building a [type of application] that will [main purpose].
-
-## Core Features
-
--   Feature 1
--   Feature 2
--   Feature 3
-
-## Target Users
-
-[Describe who will use your application]
-
-## Technical Preferences (optional)
-
--   Any specific technologies you want to use
--   Any specific requirements or constraints
+```text
+my-writing-project/
+├─ outline.md
+├─ chapters/
+│  ├─ chapter1.md
+│  └─ chapter2.md
+├─ references/
+│  └─ research-notes.md
 ```
 
-### .clinerules Template
-
-```markdown
-# Project Configuration
-
-## Tech Stack
-
--   Next.js 14+ with App Router
--   Tailwind CSS for styling
--   Supabase for backend
--   Vercel for deployment
--   GitHub for version control
-
-## Project Structure
-
-/src
-/app # Next.js App Router pages
-/components # React components
-/lib # Utility functions
-/types # TypeScript types
-/supabase
-/migrations # SQL migration files
-/seed # Seed data files
-/public # Static assets
-
-## Database Migrations
-
-SQL files in /supabase/migrations should:
-
--   Use sequential numbering: 001, 002, etc.
--   Include descriptive names
--   Be reviewed by Cline before execution
-    Example: 001_create_users_table.sql
-
-## Development Workflow
-
--   Cline helps write and review code changes
--   Vercel automatically deploys from main branch
--   Database migrations reviewed by Cline before execution
-
-## Security
-
-DO NOT read or modify:
-
--   .env files
--   \*_/config/secrets._
--   Any file containing API keys or credentials
-```
-
-### Learning Resources (2025)
-
-Want to learn more about the technologies we're using? Here are some great resources:
-
-#### Next.js and React
-
--   [Official Learn Next.js Course](https://nextjs.org/learn) - Interactive tutorial
--   [NextJS App Router: Modern Web Dev in 1 Hour](https://www.youtube.com/nextjs-modern) - Quick overview
--   [Building Real-World Apps with Next.js](https://www.youtube.com/nextjs-real-world) - Practical examples
-
-#### Supabase
-
--   [Supabase From Scratch](https://www.udemy.com/supabase-scratch) - Comprehensive course
--   [Official Quickstart Guides](https://supabase.com/docs/guides/getting-started)
--   [Real-Time Apps with Next.js and Supabase](https://www.newline.co/courses/supabase-nextjs)
-
-#### Tailwind CSS
-
--   [Tailwind CSS Tutorial for Beginners](https://www.youtube.com/tailwind-2025)
--   [Official Tailwind Documentation](https://tailwindcss.com/docs)
--   Interactive course at [Scrimba Tailwind CSS Course](https://scrimba.com/learn/tailwind)
-
-### Other Things to Know
-
-#### Working with Git & GitHub
-
-Git helps you track changes in your code and collaborate with others. Here are the essential commands you'll use:
-
-**Daily Development**
-
-```bash
-# Save your changes (do this often!)
-git add .                                    # Stage all changed files
-git commit -m "Add login page"              # Save changes with a clear message
-
-# Share your changes
-git push origin main                        # Upload to GitHub
-```
-
-**Common Workflow**
-
-1.  **Start of day**: Get latest changes
-
-    ```bash
-    git pull origin main                     # Download latest code
-    ```
-
-2.  **During development**: Save work regularly
-
-    ```bash
-    git add .
-    git commit -m "Clear message about changes"
-    ```
-
-3.  **End of day**: Share your progress
-
-    ```bash
-    git push origin main                     # Upload to GitHub
-    ```
-
-**Best Practices**
-
--   Commit often with clear messages
--   Pull before starting new work
--   Push completed work to share with others
--   Use `.gitignore` to avoid committing sensitive files
-
-> **Tip**: Vercel automatically deploys when you push to main!
-
-#### Environment Variables
-
--   Store secrets in `.env.local` for development
--   Add them to Vercel project settings for production
--   Never commit `.env` files to Git
-
-#### Getting Help
-
-1. Use `/help` in Cline chat for immediate assistance
-2. Check [Cline Documentation](https://docs.cline.bot)
-3. Join our [Discord Community](https://discord.gg/cline)
-4. Search GitHub issues for common problems
-
-Remember: Cline is here to help at every step. Just ask for guidance or clarification when needed!
+Organizing your work like this helps Cline maintain context and makes it easy to move between planning and writing phases.


### PR DESCRIPTION
## Summary
- rework new writers guide
- replace tech stack guide with writing toolkit
- rewrite Plan & Act as Plan & Draft
- update commands and mentions for writing examples
- document new writing tools
- adjust docs configuration for writing focus

## Testing
- `npm test` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_686584127000832ab5e3b9051f3e50dc