### PR TITLE
Add document tools

### DIFF
--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -26,8 +26,10 @@ export const toolUseNames = [
 	"new_task",
 	"condense",
 	"report_bug",
-	"new_rule",
-	"web_fetch",
+        "new_rule",
+        "web_fetch",
+        "create_outline",
+        "insert_citation",
 ] as const
 
 // Converts array of tool call names into a union type ("execute_command" | "read_file" | ...)
@@ -58,8 +60,10 @@ export const toolParamNames = [
 	"title",
 	"what_happened",
 	"steps_to_reproduce",
-	"api_request_output",
-	"additional_context",
+        "api_request_output",
+        "additional_context",
+        "citation",
+        "marker",
 ] as const
 
 export type ToolParamName = (typeof toolParamNames)[number]

--- a/src/core/prompts/createOutlineTool.ts
+++ b/src/core/prompts/createOutlineTool.ts
@@ -1,0 +1,20 @@
+import { ToolDefinition } from "@core/prompts/model_prompts/jsonToolToXml"
+
+export const createOutlineToolName = "CreateOutline"
+
+const descriptionForAgent = `Generate an outline from a Markdown, LaTeX or DOCX file by analyzing its headings. The outline is returned as markdown and the file is not modified.`
+
+export const createOutlineToolDefinition: ToolDefinition = {
+    name: createOutlineToolName,
+    descriptionForAgent,
+    inputSchema: {
+        type: "object",
+        properties: {
+            file_path: {
+                type: "string",
+                description: "Path to the Markdown, LaTeX or DOCX file",
+            },
+        },
+        required: ["file_path"],
+    },
+}

--- a/src/core/prompts/insertCitationTool.ts
+++ b/src/core/prompts/insertCitationTool.ts
@@ -1,0 +1,28 @@
+import { ToolDefinition } from "@core/prompts/model_prompts/jsonToolToXml"
+
+export const insertCitationToolName = "InsertCitation"
+
+const descriptionForAgent = `Insert a citation into a Markdown or LaTeX document. The citation text is inserted after the first occurrence of the given marker.`
+
+export const insertCitationToolDefinition: ToolDefinition = {
+    name: insertCitationToolName,
+    descriptionForAgent,
+    inputSchema: {
+        type: "object",
+        properties: {
+            file_path: {
+                type: "string",
+                description: "Path to the Markdown or LaTeX file to modify",
+            },
+            citation: {
+                type: "string",
+                description: "Citation text to insert",
+            },
+            marker: {
+                type: "string",
+                description: "Marker string in the file after which the citation should be inserted",
+            },
+        },
+        required: ["file_path", "citation", "marker"],
+    },
+}

--- a/src/core/prompts/model_prompts/claude4-experimental.ts
+++ b/src/core/prompts/model_prompts/claude4-experimental.ts
@@ -25,6 +25,8 @@ import { attemptCompletionToolDefinition } from "@core/tools/attemptCompletionTo
 import { browserActionToolDefinition } from "@core/tools/browserActionTool"
 import { newTaskToolDefinition } from "@core/tools/newTaskTool"
 import { editToolDefinition } from "@/core/tools/editTool"
+import { createOutlineToolDefinition } from "@core/prompts/createOutlineTool"
+import { insertCitationToolDefinition } from "@core/prompts/insertCitationTool"
 
 export const SYSTEM_PROMPT_CLAUDE4_EXPERIMENTAL = async (
 	cwd: string,
@@ -334,10 +336,12 @@ You accomplish a given task iteratively, breaking it down into clear steps and w
 		listCodeDefinitionNamesTool,
 		useMCPToolDefinition,
 		accessMcpResourceToolDefinition,
-		loadMcpDocumentationTool,
-		newTaskToolDefinition,
-		editToolDefinition,
-	]
+                loadMcpDocumentationTool,
+                newTaskToolDefinition,
+                editToolDefinition,
+                createOutlineToolDefinition,
+                insertCitationToolDefinition,
+        ]
 	if (supportsBrowserUse) {
 		tools.push(browserActionTool)
 	}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -57,6 +57,7 @@ import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, LanguageDisplay } from "@sha
 import { ClineAskResponse, ClineCheckpointRestore } from "@shared/WebviewMessage"
 import { calculateApiCostAnthropic } from "@utils/cost"
 import { fileExistsAtPath } from "@utils/fs"
+import fs from "fs/promises"
 import { createAndOpenGitHubIssue } from "@utils/github-url-utils"
 import { arePathsEqual, getReadablePath, isLocatedInWorkspace } from "@utils/path"
 import { fixModelHtmlEscaping, removeInvalidChars } from "@utils/string"
@@ -1624,18 +1625,28 @@ export class Task {
 				case "read_file":
 				case "list_files":
 				case "list_code_definition_names":
-				case "search_files":
-					return [
-						this.autoApprovalSettings.actions.readFiles,
-						this.autoApprovalSettings.actions.readFilesExternally ?? false,
-					]
-				case "new_rule":
-				case "write_to_file":
-				case "replace_in_file":
-					return [
-						this.autoApprovalSettings.actions.editFiles,
-						this.autoApprovalSettings.actions.editFilesExternally ?? false,
-					]
+                                case "search_files":
+                                        return [
+                                                this.autoApprovalSettings.actions.readFiles,
+                                                this.autoApprovalSettings.actions.readFilesExternally ?? false,
+                                        ]
+                                case "create_outline":
+                                        return [
+                                                this.autoApprovalSettings.actions.readFiles,
+                                                this.autoApprovalSettings.actions.readFilesExternally ?? false,
+                                        ]
+                                case "new_rule":
+                                case "write_to_file":
+                                case "replace_in_file":
+                                        return [
+                                                this.autoApprovalSettings.actions.editFiles,
+                                                this.autoApprovalSettings.actions.editFilesExternally ?? false,
+                                        ]
+                                case "insert_citation":
+                                        return [
+                                                this.autoApprovalSettings.actions.editFiles,
+                                                this.autoApprovalSettings.actions.editFilesExternally ?? false,
+                                        ]
 				case "execute_command":
 					return [
 						this.autoApprovalSettings.actions.executeSafeCommands ?? false,
@@ -2160,10 +2171,14 @@ export class Task {
 							return `[${block.name}]`
 						case "new_rule":
 							return `[${block.name} for '${block.params.path}']`
-						case "web_fetch":
-							return `[${block.name} for '${block.params.url}']`
-					}
-				}
+                                                case "web_fetch":
+                                                        return `[${block.name} for '${block.params.url}']`
+                                                case "create_outline":
+                                                        return `[${block.name} for '${block.params.path}']`
+                                                case "insert_citation":
+                                                        return `[${block.name} for '${block.params.path}']`
+                                        }
+                                }
 
 				if (this.didRejectTool) {
 					// ignore any tool content after user has rejected tool once
@@ -2753,17 +2768,95 @@ export class Task {
 								// Track file read operation
 								await this.fileContextTracker.trackFileContext(relPath, "read_tool")
 
-								pushToolResult(content)
-								await this.saveCheckpoint()
-								break
-							}
-						} catch (error) {
-							await handleError("reading file", error)
-							await this.saveCheckpoint()
-							break
-						}
-					}
-					case "list_files": {
+                                                                pushToolResult(content)
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+                                                } catch (error) {
+                                                        await handleError("reading file", error)
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                }
+                                        }
+                                        case "create_outline": {
+                                                const relPath: string | undefined = block.params.path
+                                                try {
+                                                        if (!relPath) {
+                                                                this.consecutiveMistakeCount++
+                                                                pushToolResult(await this.sayAndCreateMissingParamError("create_outline", "path"))
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+
+                                                        const accessAllowed = this.clineIgnoreController.validateAccess(relPath)
+                                                        if (!accessAllowed) {
+                                                                await this.say("clineignore_error", relPath)
+                                                                pushToolResult(formatResponse.toolError(formatResponse.clineIgnoreError(relPath)))
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+
+                                                        const absolutePath = path.resolve(cwd, relPath)
+                                                        const fileText = await extractTextFromFile(absolutePath)
+                                                        const outline = fileText
+                                                                .split(/\r?\n/)
+                                                                .filter((l) => l.trim().match(/^#|\\\w*section\{|^\\\\section/))
+                                                                .map((l) => `- ${l.replace(/[#{}]/g, "").trim()}`)
+                                                                .join("\n")
+
+                                                        await this.fileContextTracker.trackFileContext(relPath, "read_tool")
+
+                                                        pushToolResult(outline || "No headings found.")
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                } catch (error) {
+                                                        await handleError("creating outline", error)
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                }
+                                        }
+                                        case "insert_citation": {
+                                                const relPath: string | undefined = block.params.path
+                                                const citation: string | undefined = block.params.citation
+                                                const marker: string | undefined = block.params.marker
+                                                try {
+                                                        if (!relPath || !citation || !marker) {
+                                                                this.consecutiveMistakeCount++
+                                                                let missing = !relPath ? "path" : !citation ? "citation" : "marker"
+                                                                pushToolResult(await this.sayAndCreateMissingParamError("insert_citation", missing))
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+
+                                                        const accessAllowed = this.clineIgnoreController.validateAccess(relPath)
+                                                        if (!accessAllowed) {
+                                                                await this.say("clineignore_error", relPath)
+                                                                pushToolResult(formatResponse.toolError(formatResponse.clineIgnoreError(relPath)))
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+
+                                                        const absolutePath = path.resolve(cwd, relPath)
+                                                        let text = await fs.readFile(absolutePath, "utf8")
+                                                        const idx = text.indexOf(marker)
+                                                        if (idx === -1) {
+                                                                pushToolResult(formatResponse.toolError(`Marker not found in ${relPath}`))
+                                                                await this.saveCheckpoint()
+                                                                break
+                                                        }
+                                                        text = text.slice(0, idx + marker.length) + citation + text.slice(idx + marker.length)
+                                                        await fs.writeFile(absolutePath, text)
+                                                        this.fileContextTracker.markFileAsEditedByCline(relPath)
+                                                        pushToolResult(`Citation inserted into ${relPath}`)
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                } catch (error) {
+                                                        await handleError("inserting citation", error)
+                                                        await this.saveCheckpoint()
+                                                        break
+                                                }
+                                        }
+                                        case "list_files": {
 						const isClaude4Model = isClaude4ModelFamily(this.api)
 						const relDirPath: string | undefined = block.params.path
 						const recursiveRaw: string | undefined = block.params.recursive


### PR DESCRIPTION
## Summary
- define `CreateOutline` and `InsertCitation` tools
- expose new tool names in prompts and system model
- extend `Task` to handle outline generation and citation insertion
- include new tool names in Claude system prompt

## Testing
- `npm test` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_686583e29b94832a8769a003f3230da8